### PR TITLE
Fix indentation in Homebrew formulae

### DIFF
--- a/Homebrew/Lion-Mavericks/bsdgames-osx.rb
+++ b/Homebrew/Lion-Mavericks/bsdgames-osx.rb
@@ -20,7 +20,7 @@ class BsdgamesOsx < Formula
 
   def test
     %w[ pom ].each do |game|
-  system game
-      end
+      system game
+    end
   end
 end

--- a/Homebrew/Sierra/bsdgames-osx.rb
+++ b/Homebrew/Sierra/bsdgames-osx.rb
@@ -21,8 +21,8 @@ class BsdgamesOsx < Formula
 
   def test
     %w[ pom ].each do |game|
-  system game
-      end
+      system game
+    end
   end
 end
 

--- a/Homebrew/Yosemite/bsdgames-osx.rb
+++ b/Homebrew/Yosemite/bsdgames-osx.rb
@@ -21,7 +21,7 @@ class BsdgamesOsx < Formula
 
   def test
     %w[ pom ].each do |game|
-  system game
-      end
+      system game
+    end
   end
 end


### PR DESCRIPTION
Code cosmetic fix. The indentation in the `test` blocks in the Homebrew formulae is a little messed up. This PR fixes it.